### PR TITLE
Only run express thru pm2 and no-need to run gatsby serve on backend

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: pm2 start ecosystem.config.js --env production && gatsby serve -p $PORT -H 0.0.0.0
+web: yarn start

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -3,12 +3,15 @@ module.exports = {
 		{
 			name: 'siris-technology',
 			script: 'server.js',
-			instances: 1,
-			// instances: process.env.APP_INSTANCES || 'max',
+			// instances: 1,
+			instances: process.env.APP_INSTANCES || 'max',
 			autorestart: true,
 			watch: false,
 			max_memory_restart: process.env.APP_MEMORY_LIMIT || '2G',
 			env: {
+				NODE_ENV: 'development',
+			},
+			env_development: {
 				NODE_ENV: 'development',
 			},
 			env_production: {

--- a/package.json
+++ b/package.json
@@ -46,10 +46,10 @@
 	"license": "MIT",
 	"scripts": {
 		"preinstall": "node tools/preinstall-script.js",
-		"build": "gatsby build",
 		"start:dev": "pm2 start ecosystem.config.js --env development && gatsby develop",
 		"stop:dev": "pm2 kill",
-		"start": "pm2 start ecosystem.config.js --env production && gatsby serve",
+		"build": "gatsby build",
+		"start": "pm2-runtime start ecosystem.config.js --env production",
 		"format": "prettier --write \"src/**/*.js\"",
 		"reset": "rm -rf .cache/ public/",
 		"test": "echo \"Write tests! -> https://gatsby.app/unit-testing\""


### PR DESCRIPTION
Also, runs maximum no of instances/threads  (8 usually)